### PR TITLE
Test & fix for handling explicit alpha of 0

### DIFF
--- a/color-string.js
+++ b/color-string.js
@@ -68,7 +68,7 @@ function getRgba(string) {
    for (var i = 0; i < rgb.length; i++) {
       rgb[i] = scale(rgb[i], 0, 255);
    }
-   if (!a) {
+   if (!a && a != 0) {
       a = 1;
    }
    else {

--- a/test/basic.js
+++ b/test/basic.js
@@ -16,6 +16,7 @@ assert.equal(string.getAlpha("hsla(244, 100%, 100%, 0.6)"), 0.6);
 
 // alpha
 assert.deepEqual(string.getRgba("rgba(200, 20, 233, 0.2)"), [200, 20, 233, 0.2]);
+assert.deepEqual(string.getRgba("rgba(200, 20, 233, 0)"), [200, 20, 233, 0]);
 assert.deepEqual(string.getRgba("rgba(100%, 30%, 90%, 0.2)"), [255, 77, 229, 0.2]);
 assert.deepEqual(string.getHsla("hsla(200, 20%, 33%, 0.2)"), [200, 20, 33, 0.2]);
 


### PR DESCRIPTION
When getRgba parses something like `rgba(200, 20, 233, 0)`, the check for `!a` treats `0` as false and sets it back to `1`. I added another check for `0` (there's probably a more succinct way to do it) and a corresponding test.
