### PR TITLE
Support `deg` notation for hsl & hwb

### DIFF
--- a/color-string.js
+++ b/color-string.js
@@ -84,7 +84,7 @@ function getHsla(string) {
    if (!string) {
       return;
    }
-   var hsl = /^hsla?\(\s*(\d+)\s*,\s*([\d\.]+)%\s*,\s*([\d\.]+)%\s*(?:,\s*([\d\.]+)\s*)?\)/;
+   var hsl = /^hsla?\(\s*(\d+)(?:deg)?\s*,\s*([\d\.]+)%\s*,\s*([\d\.]+)%\s*(?:,\s*([\d\.]+)\s*)?\)/;
    var match = string.match(hsl);
    if (match) {
       var h = scale(parseInt(match[1]), 0, 360),
@@ -99,7 +99,7 @@ function getHwb(string) {
    if (!string) {
       return;
    }
-   var hwb = /^hwb\(\s*(\d+)\s*,\s*([\d\.]+)%\s*,\s*([\d\.]+)%\s*(?:,\s*([\d\.]+)\s*)?\)/;
+   var hwb = /^hwb\(\s*(\d+)(?:deg)?\s*,\s*([\d\.]+)%\s*,\s*([\d\.]+)%\s*(?:,\s*([\d\.]+)\s*)?\)/;
    var match = string.match(hwb);
    if (match) {
       var h = scale(parseInt(match[1]), 0, 360),

--- a/test/basic.js
+++ b/test/basic.js
@@ -8,7 +8,9 @@ assert.deepEqual(string.getRgba("rgb(100%, 30%, 90%)"), [255, 77, 229, 1]);
 assert.deepEqual(string.getRgba("blue"), [0, 0, 255, 1]);
 assert.deepEqual(string.getRgba("transparent"), [0, 0, 0, 0]);
 assert.deepEqual(string.getHsla("hsl(240, 100%, 50.5%)"), [240, 100, 50.5, 1]);
+assert.deepEqual(string.getHsla("hsl(240deg, 100%, 50.5%)"), [240, 100, 50.5, 1]);
 assert.deepEqual(string.getHwb("hwb(240, 100%, 50.5%)"), [240, 100, 50.5, 1]);
+assert.deepEqual(string.getHwb("hwb(240deg, 100%, 50.5%)"), [240, 100, 50.5, 1]);
 
 assert.equal(string.getAlpha("rgb(244, 233, 100)"), 1);
 assert.equal(string.getAlpha("rgba(244, 233, 100, 0.5)"), 0.5);


### PR DESCRIPTION
<hue> can be an integer (considered as a degree) or an angle (which can
be other things than a degree but it’s better than nothing to read
`deg` right ?)

References:
- http://dev.w3.org/csswg/css-color/#the-hsl-notation
- http://dev.w3.org/csswg/css-color/#the-hwb-notation
- http://dev.w3.org/csswg/css-values-3/#angle-value
