### PR TITLE
fixing bug with ever-growing array

### DIFF
--- a/color-string.js
+++ b/color-string.js
@@ -76,7 +76,7 @@ function getRgba(string) {
    else {
       a = scale(a, 0, 1);
    }
-   rgb.push(a);
+   rgb[3] = a;
    return rgb;
 }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,16 +1,20 @@
 var string = require("../color-string"),
     assert = require("assert");
 
+
 assert.deepEqual(string.getRgba("#fef"), [255, 238, 255, 1]);
 assert.deepEqual(string.getRgba("#fffFEF"), [255, 255, 239,1]);
 assert.deepEqual(string.getRgba("rgb(244, 233, 100)"), [244, 233, 100, 1]);
 assert.deepEqual(string.getRgba("rgb(100%, 30%, 90%)"), [255, 77, 229, 1]);
-assert.deepEqual(string.getRgba("blue"), [0, 0, 255, 1]);
 assert.deepEqual(string.getRgba("transparent"), [0, 0, 0, 0]);
 assert.deepEqual(string.getHsla("hsl(240, 100%, 50.5%)"), [240, 100, 50.5, 1]);
 assert.deepEqual(string.getHsla("hsl(240deg, 100%, 50.5%)"), [240, 100, 50.5, 1]);
 assert.deepEqual(string.getHwb("hwb(240, 100%, 50.5%)"), [240, 100, 50.5, 1]);
 assert.deepEqual(string.getHwb("hwb(240deg, 100%, 50.5%)"), [240, 100, 50.5, 1]);
+
+//subsequent return values should not change array
+assert.deepEqual(string.getRgba("blue"), [0, 0, 255, 1]);
+assert.deepEqual(string.getRgba("blue"), [0, 0, 255, 1]); 
 
 assert.equal(string.getAlpha("rgb(244, 233, 100)"), 1);
 assert.equal(string.getAlpha("rgba(244, 233, 100, 0.5)"), 0.5);


### PR DESCRIPTION
Consecutive keyword conversions will cause the alpha components to be constantly pushed onto the end of the array, rather than set as the 4th component. 

This code demonstrates the current issue:

``` js
colorString.getRgb("blue")
colorString.getRgb("blue")
var out = colorString.getRgb("blue")

console.log( out.length <= 4 ) // false
```
