### PR TITLE
use color-name 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "./color-string",
   "dependencies": {
-    "color-name": "0.0.x"
+    "color-name": "1.0.0"
   },
   "devDependencies": {
     "browserify": ">=1.0.0",


### PR DESCRIPTION
Fix bug introduced in https://github.com/harthur/color-string/commit/426e35416c6c776443898eb60b8043e1044ebc8f
Ref https://github.com/cssnext/cssnext/issues/53
