### PR TITLE
Returning null for hsl/hwb values that have additional characters after closing paren

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ cs.get.hsl = function (string) {
 		return null;
 	}
 
-	var hsl = /^hsla?\(\s*([+-]?\d*[\.]?\d+)(?:deg)?\s*,\s*([+-]?[\d\.]+)%\s*,\s*([+-]?[\d\.]+)%\s*(?:,\s*([+-]?[\d\.]+)\s*)?\)/;
+	var hsl = /^hsla?\(\s*([+-]?\d*[\.]?\d+)(?:deg)?\s*,\s*([+-]?[\d\.]+)%\s*,\s*([+-]?[\d\.]+)%\s*(?:,\s*([+-]?[\d\.]+)\s*)?\)$/;
 	var match = string.match(hsl);
 
 	if (match) {
@@ -127,6 +127,8 @@ cs.get.hsl = function (string) {
 
 		return [h, s, l, a];
 	}
+
+	return null;
 };
 
 cs.get.hwb = function (string) {
@@ -134,7 +136,7 @@ cs.get.hwb = function (string) {
 		return null;
 	}
 
-	var hwb = /^hwb\(\s*([+-]?\d*[\.]?\d+)(?:deg)?\s*,\s*([+-]?[\d\.]+)%\s*,\s*([+-]?[\d\.]+)%\s*(?:,\s*([+-]?[\d\.]+)\s*)?\)/;
+	var hwb = /^hwb\(\s*([+-]?\d*[\.]?\d+)(?:deg)?\s*,\s*([+-]?[\d\.]+)%\s*,\s*([+-]?[\d\.]+)%\s*(?:,\s*([+-]?[\d\.]+)\s*)?\)$/;
 	var match = string.match(hwb);
 
 	if (match) {
@@ -145,6 +147,8 @@ cs.get.hwb = function (string) {
 		var a = clamp(isNaN(alpha) ? 1 : alpha, 0, 1);
 		return [h, w, b, a];
 	}
+
+	return null;
 };
 
 cs.to.hex = function (rgb) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -70,6 +70,9 @@ assert.deepEqual(string.get.hwb('hwb(400, 10%, 200%, 10)'), [40, 10, 100, 1]);
 assert.strictEqual(string.get.rgb('yellowblue'), null);
 assert.strictEqual(string.get.rgb('hsl(100, 10%, 10%)'), null);
 assert.strictEqual(string.get.rgb('hwb(100, 10%, 10%)'), null);
+assert.strictEqual(string.get.rgb('rgb(123, 255, 9)1234'), null);
+assert.strictEqual(string.get.hsl('hsl(41, 50%, 45%)1234'), null);
+assert.strictEqual(string.get.hwb('hwb(240, 100%, 50.5%)1234'), null);
 
 // generators
 assert.equal(string.to.hex([255, 10, 35]), '#FF0A23');


### PR DESCRIPTION
The Regexes for `cs.get.hsl` and `cs.get.hwb` seem to lack an ending `$` anchor, making strings like `hsl(100, 50%, 50%)asdf` return the parsed array rather than `null`. It seems that `cs.get.rgb` has the anchor. This behavior should be consistent, and I'm inclined to believe that the rgb Regex has it right and the return value for an invalid color string should always be `null`, even if the beginning of the string is valid.