### PR TITLE
Fix shorthand alpha channel parsing.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ cs.get.rgb = function (string) {
 		return null;
 	}
 
-	var abbr = /^#([a-f0-9]{3,4})$/i;
+	var abbr = /^#([a-f0-9]{3})([a-f0-9]{1})?$/i;
 	var hex = /^#([a-f0-9]{6})([a-f0-9]{2})?$/i;
 	var rgba = /^rgba?\(\s*([+-]?\d+)\s*,\s*([+-]?\d+)\s*,\s*([+-]?\d+)\s*(?:,\s*([+-]?[\d\.]+)\s*)?\)$/;
 	var per = /^rgba?\(\s*([+-]?[\d\.]+)\%\s*,\s*([+-]?[\d\.]+)\%\s*,\s*([+-]?[\d\.]+)\%\s*(?:,\s*([+-]?[\d\.]+)\s*)?\)$/;
@@ -58,15 +58,15 @@ cs.get.rgb = function (string) {
 	var hexAlpha;
 
 	if (match = string.match(abbr)) {
+		hexAlpha = match[2];
 		match = match[1];
-		hexAlpha = match[3];
 
 		for (i = 0; i < 3; i++) {
 			rgb[i] = parseInt(match[i] + match[i], 16);
 		}
 
 		if (hexAlpha) {
-			rgb[3] = Math.round(parseInt(hexAlpha + hexAlpha, 16) / 255);
+			rgb[3] = Math.round((parseInt(hexAlpha + hexAlpha, 16) / 255) * 100) / 100;
 		}
 	} else if (match = string.match(hex)) {
 		hexAlpha = match[2];

--- a/test/basic.js
+++ b/test/basic.js
@@ -55,6 +55,7 @@ assert.deepEqual(string.get.rgb('blue'), [0, 0, 255, 1]);
 assert.deepEqual(string.get.rgb('blue'), [0, 0, 255, 1]);
 
 // alpha
+assert.deepEqual(string.get.rgb('#fffa'), [255, 255, 255, 0.67]);
 assert.deepEqual(string.get.rgb('#c814e933'), [200, 20, 233, 0.2]);
 assert.deepEqual(string.get.rgb('#c814e900'), [200, 20, 233, 0]);
 assert.deepEqual(string.get.rgb('#c814e9ff'), [200, 20, 233, 1]);


### PR DESCRIPTION
The previous behaviour would always set the alpha channel to `1`. This has been fixed, and I've also added a test case to prevent a regression.