### PR TITLE
added CDN publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+*.log
+.DS_Store
+/umd.js

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
   "repository": "Qix-/color-string",
   "scripts": {
     "pretest": "xo",
-    "test": "node test/basic.js"
+    "test": "node test/basic.js",
+    "prepublish": "rollup --config"
   },
   "license": "MIT",
   "files": [
-    "index.js"
+    "index.js",
+    "umd.js"
   ],
   "xo": {
     "rules": {
@@ -28,6 +30,9 @@
     "simple-swizzle": "^0.2.2"
   },
   "devDependencies": {
+    "rollup": "^0.66.6",
+    "rollup-plugin-commonjs": "^9.2.0",
+    "rollup-plugin-node-resolve": "^3.4.0",
     "xo": "^0.12.1"
   },
   "keywords": [
@@ -35,5 +40,6 @@
     "colour",
     "rgb",
     "css"
-  ]
+  ],
+  "unpkg": "umd.js"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,17 @@
+// rollup.config.js
+import commonjs from 'rollup-plugin-commonjs'
+import nodeResolve from 'rollup-plugin-node-resolve'
+
+export default {
+  input: 'index.js',
+  output: {
+    file: 'umd.js',
+    format: 'umd',
+    name: 'ColorString',
+    exports: 'named'
+  },
+  plugins: [
+    nodeResolve(),
+    commonjs({ sourceMap: false })
+  ]
+}


### PR DESCRIPTION
This resolves #9 which I know is an old issue, but hear me out:

There are often situations where having a pre-built file is handy (like from a CDN for a codepen or fiddle, where it can't be built, or just trying an idea out in a regular HTML file, with no build system.) [unkpkg](https://unpkg.com) will CDN anything in npm. I completely agree a module-based workflow is superior (I use ES6 modules, primarily, instead of CommonJS) but this works for everyone, with no extra effort.

These changes are pretty minimal, and you don't have to do anything extra (just `npm i`, like normal, then `npm publish`.) It doesn;t add any built files to your repo, or really require anything else.

If you accept the PR, make sure to `npm version patch` and `npm publish`, so it gets built and sent up to npm.
