### PR TITLE
Fix hue modulo operation

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ cs.get.hsl = function (string) {
 
 	if (match) {
 		var alpha = parseFloat(match[4]);
-		var h = (parseFloat(match[1]) + 360) % 360;
+		var h = ((parseFloat(match[1]) % 360) + 360) % 360;
 		var s = clamp(parseFloat(match[2]), 0, 100);
 		var l = clamp(parseFloat(match[3]), 0, 100);
 		var a = clamp(isNaN(alpha) ? 1 : alpha, 0, 1);

--- a/test/basic.js
+++ b/test/basic.js
@@ -30,6 +30,7 @@ assert.deepEqual(string.get('rgb(244, 233, 100)'), {model: 'rgb', value: [244, 2
 assert.deepEqual(string.get('rgb(100%, 30%, 90%)'), {model: 'rgb', value: [255, 77, 229, 1]});
 assert.deepEqual(string.get('transparent'), {model: 'rgb', value: [0, 0, 0, 0]});
 assert.deepEqual(string.get('hsl(240, 100%, 50.5%)'), {model: 'hsl', value: [240, 100, 50.5, 1]});
+assert.deepEqual(string.get('hsl(-480, 100%, 50.5%)'), {model: 'hsl', value: [240, 100, 50.5, 1]});
 assert.deepEqual(string.get('hsl(240deg, 100%, 50.5%)'), {model: 'hsl', value: [240, 100, 50.5, 1]});
 assert.deepEqual(string.get('hwb(240, 100%, 50.5%)'), {model: 'hwb', value: [240, 100, 50.5, 1]});
 assert.deepEqual(string.get('hwb(240deg, 100%, 50.5%)'), {model: 'hwb', value: [240, 100, 50.5, 1]});


### PR DESCRIPTION
This modulo operation was removed in #37 under the mistaken impression that it was unnecessary. However, it's required for a proper "wrapping modulo"--without it, hue values lower than -360 will not be made positive.

I've added a test that checks for such a case specifically.