### PR TITLE
Fix rgb alpha percentage parsing from int to float

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ cs.get.rgb = function (string) {
 
 		if (match[4]) {
 			if (match[5]) {
-				rgb[3] = parseInt(match[4], 0) * 0.01;
+				rgb[3] = parseFloat(match[4]) * 0.01;
 			} else {
 				rgb[3] = parseFloat(match[4]);
 			}
@@ -102,7 +102,7 @@ cs.get.rgb = function (string) {
 
 		if (match[4]) {
 			if (match[5]) {
-				rgb[3] = parseInt(match[4], 0) * 0.01;
+				rgb[3] = parseFloat(match[4]) * 0.01;
 			} else {
 				rgb[3] = parseFloat(match[4]);
 			}

--- a/test/basic.js
+++ b/test/basic.js
@@ -114,6 +114,8 @@ assert.deepEqual(string.get.hwb('hwb(400, 10%, 200%, 0)'), [40, 10, 100, 0]);
 // range
 assert.deepEqual(string.get.rgb('rgba(300, 600, 100, 3)'), [255, 255, 100, 1]);
 assert.deepEqual(string.get.rgb('rgba(300 600 100 / 3)'), [255, 255, 100, 1]);
+assert.deepEqual(string.get.rgb('rgba(300 600 100 / 130%)'), [255, 255, 100, 1]);
+assert.deepEqual(string.get.rgb('rgba(300 600 100 / -130%)'), [255, 255, 100, 0]);
 assert.deepEqual(string.get.rgb('rgba(8000%, 100%, 333%, 88)'), [255, 255, 255, 1]);
 assert.deepEqual(string.get.rgb('rgba(8000% 100% 333% / 88)'), [255, 255, 255, 1]);
 assert.deepEqual(string.get.hsl('hsla(400, 10%, 200%, 10)'), [40, 10, 100, 1]);


### PR DESCRIPTION
I used this method here https://stackoverflow.com/a/18908122/1889685 to convert the percentage to fraction, because there are issues with JS floating points.

For example:
```js
20.2 * 0.01 == 0.20199999999999999 // ❌
```
```js
var a = 20.2;
var b = 0.01;
var cf = 100;
(a * cf) * (b * cf) / (cf * cf) === 0.202 // ✅
```