### PR TITLE
Fix rgb alpha percentage parsing from int to float

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ cs.get.rgb = function (string) {
 
 		if (match[4]) {
 			if (match[5]) {
-				rgb[3] = parseInt(match[4], 0) * 0.01;
+				rgb[3] = parseFloat(match[4]) * 0.01;
 			} else {
 				rgb[3] = parseFloat(match[4]);
 			}
@@ -102,7 +102,7 @@ cs.get.rgb = function (string) {
 
 		if (match[4]) {
 			if (match[5]) {
-				rgb[3] = parseInt(match[4], 0) * 0.01;
+				rgb[3] = parseFloat(match[4]) * 0.01;
 			} else {
 				rgb[3] = parseFloat(match[4]);
 			}


### PR DESCRIPTION
I messed up the previous fork. This has just `parseInt` changed to `parseFloat`.
