### PR TITLE
fix to.keyword returning Object.prototype values

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var colorNames = require('color-name');
 var swizzle = require('simple-swizzle');
 var hasOwnProperty = Object.hasOwnProperty;
 
-var reverseNames = {};
+var reverseNames = Object.create(null);
 
 // create a list of reverse color names
 for (var name in colorNames) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -216,6 +216,7 @@ assert.equal(string.to.hwb([280, 40, 60], 0.3), 'hwb(280, 40%, 60%, 0.3)');
 assert.equal(string.to.hwb([280, 40, 60], 0), 'hwb(280, 40%, 60%, 0)');
 
 assert.equal(string.to.keyword([255, 255, 0]), 'yellow');
+assert.equal(string.to.keyword(['constructor']), undefined);
 assert.equal(string.to.keyword([100, 255, 0]), undefined);
 
 // Make sure .get() doesn't return object prototype values (regression test, #44)


### PR DESCRIPTION
```
$ node
Welcome to Node.js v16.9.1.
Type ".help" for more information.
> require('color-string').to.keyword(['constructor'])
[Function: Object]
```

The package had unexpected behavior when passing properties of Object.prototype to `to.keyword`. Using a null prototype for `reverseNames` fixes the issue.