### PR TITLE
Change typings to always return null instead of undefined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,20 +2,20 @@ export type Model = 'rgb' | 'hsl' | 'hwb';
 
 export type ColorString = {
 	get: {
-		(color: string): {model: Model; value: number[]} | undefined;
-		rgb: (color: string) => number[] | undefined;
-		hsl: (color: string) => number[] | undefined;
-		hwb: (color: string) => number[] | undefined;
+		(color: string): {model: Model; value: number[]} | null;
+		rgb: (color: string) => number[] | null;
+		hsl: (color: string) => number[] | null;
+		hwb: (color: string) => number[] | null;
 	};
 	to: {
-		hex: (r: number, g: number, b: number, a?: number) => string | undefined;
+		hex: (r: number, g: number, b: number, a?: number) => string | null;
 		rgb: {
-			(r: number, g: number, b: number, a?: number): string | undefined;
-			percent: (r: number, g: number, b: number, a?: number) => string | undefined;
+			(r: number, g: number, b: number, a?: number): string | null;
+			percent: (r: number, g: number, b: number, a?: number) => string | null;
 		};
-		keyword: (r: number, g: number, b: number, a?: number) => string | undefined;
-		hsl: (h: number, s: number, l: number, a?: number) => string | undefined;
-		hwb: (h: number, w: number, b: number, a?: number) => string | undefined;
+		keyword: (r: number, g: number, b: number, a?: number) => string | null;
+		hsl: (h: number, s: number, l: number, a?: number) => string | null;
+		hwb: (h: number, w: number, b: number, a?: number) => string | null;
 	};
 };
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,10 +1,10 @@
 import {expectType} from 'tsd';
 import colorString, {type Model} from './index.js';
 
-type GetColorResult = {model: Model; value: number[]} | undefined;
-type GetSpecificTypeResult = number[] | undefined;
+type GetColorResult = {model: Model; value: number[]} | null;
+type GetSpecificTypeResult = number[] | null;
 
-type ToColorResult = string | undefined;
+type ToColorResult = string | null;
 
 expectType<GetColorResult>(colorString.get('#FFF'));
 expectType<GetColorResult>(colorString.get('#FFFA'));

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "xo": {
     "rules": {
       "no-cond-assign": 0,
-      "operator-linebreak": 0
+      "operator-linebreak": 0,
+      "@typescript-eslint/ban-types": 0
     }
   },
   "dependencies": {


### PR DESCRIPTION
Currently the typings are wrong. All functions [are returning `null`](https://github.com/Qix-/color-string/blob/f664009755e5d06a0d6fda5c59641ebb54a230d5/index.js#L42) but the type definitions define them as `undefined` which leads to compile time and/or ESLint errors when you want to explicitly check for `null`.