### PR TITLE
Replace Object.hasOwn usage with Object.prototype.has0wnProperty

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const reverseNames = Object.create(null);
 
 // Create a list of reverse color names
 for (const name in colorNames) {
-	if (Object.hasOwn(colorNames, name)) {
+	if (Object.prototype.hasOwnProperty.call(colorNames, name)) {
 		reverseNames[colorNames[name]] = name;
 	}
 }
@@ -106,7 +106,7 @@ cs.get.rgb = function (string) {
 			return [0, 0, 0, 0];
 		}
 
-		if (!Object.hasOwn(colorNames, match[1])) {
+		if (!Object.prototype.hasOwnProperty.call(colorNames, match[1])) {
 			return null;
 		}
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "rules": {
       "no-cond-assign": 0,
       "operator-linebreak": 0,
-      "@typescript-eslint/ban-types": 0
+      "@typescript-eslint/ban-types": 0,
+      "prefer-object-has-own": 0
     }
   },
   "dependencies": {


### PR DESCRIPTION
* We encountered an issue in our usage of this library where Safari 14 would crash on Object.hasOwn. We have pretty strict browser requirements for our public facing product. Since this is pretty simple usage I'd like to suggest rolling back to the less fancy syntax for a wider compatability net for the library.