### PR TITLE
feat: Normalize string before checking it

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,9 @@ const cs = {
 	get: {},
 };
 
-cs.get = function (string) {
-	const prefix = string.slice(0, 3).toLowerCase();
+cs.get = function (string = '') {
+	string = normalizeString(string);
+	const prefix = string.slice(0, 3);
 	let value;
 	let model;
 	switch (prefix) {
@@ -45,10 +46,8 @@ cs.get = function (string) {
 	return {model, value};
 };
 
-cs.get.rgb = function (string) {
-	if (!string) {
-		return null;
-	}
+cs.get.rgb = function (string = '') {
+	string = normalizeString(string);
 
 	const abbr = /^#([a-f\d]{3,4})$/i;
 	const hex = /^#([a-f\d]{6})([a-f\d]{2})?$/i;
@@ -127,10 +126,8 @@ cs.get.rgb = function (string) {
 	return rgb;
 };
 
-cs.get.hsl = function (string) {
-	if (!string) {
-		return null;
-	}
+cs.get.hsl = function (string = '') {
+	string = normalizeString(string);
 
 	const hsl = /^hsla?\(\s*([+-]?(?:\d{0,3}\.)?\d+)(?:deg)?\s*,?\s*([+-]?[\d.]+)%\s*,?\s*([+-]?[\d.]+)%\s*(?:[,|/]\s*([+-]?(?=\.\d|\d)(?:0|[1-9]\d*)?(?:\.\d*)?(?:[eE][+-]?\d+)?)\s*)?\)$/;
 	const match = string.match(hsl);
@@ -148,10 +145,8 @@ cs.get.hsl = function (string) {
 	return null;
 };
 
-cs.get.hwb = function (string) {
-	if (!string) {
-		return null;
-	}
+cs.get.hwb = function (string = '') {
+	string = normalizeString(string);
 
 	const hwb = /^hwb\(\s*([+-]?\d{0,3}(?:\.\d+)?)(?:deg)?\s*,\s*([+-]?[\d.]+)%\s*,\s*([+-]?[\d.]+)%\s*(?:,\s*([+-]?(?=\.\d|\d)(?:0|[1-9]\d*)?(?:\.\d*)?(?:[eE][+-]?\d+)?)\s*)?\)$/;
 	const match = string.match(hwb);
@@ -225,6 +220,12 @@ function clamp(number_, min, max) {
 function hexDouble(number_) {
 	const string_ = Math.round(number_).toString(16).toUpperCase();
 	return (string_.length < 2) ? '0' + string_ : string_;
+}
+
+function normalizeString(string) {
+	string = string.toLowerCase();
+
+	return string;
 }
 
 export default cs;

--- a/test.js
+++ b/test.js
@@ -18,6 +18,8 @@ assert.deepEqual(string.get.rgb('rgb(244 233 100)'), [244, 233, 100, 1]);
 assert.deepEqual(string.get.rgb('rgb(100%, 30%, 90%)'), [255, 77, 229, 1]);
 assert.deepEqual(string.get.rgb('rgb(100% 30% 90%)'), [255, 77, 229, 1]);
 assert.deepEqual(string.get.rgb('transparent'), [0, 0, 0, 0]);
+assert.deepEqual(string.get.rgb('blue'), [0, 0, 255, 1]);
+assert.deepEqual(string.get.rgb('BLUE'), [0, 0, 255, 1]);
 assert.deepEqual(string.get.hsl('hsl(240, 100%, 50.5%)'), [240, 100, 50.5, 1]);
 assert.deepEqual(string.get.hsl('hsl(240 100% 50.5%)'), [240, 100, 50.5, 1]);
 assert.deepEqual(string.get.hsl('hsl(240deg, 100%, 50.5%)'), [240, 100, 50.5, 1]);
@@ -37,6 +39,8 @@ assert.deepEqual(string.get('rgb(244 233 100)'), {model: 'rgb', value: [244, 233
 assert.deepEqual(string.get('rgb(100%, 30%, 90%)'), {model: 'rgb', value: [255, 77, 229, 1]});
 assert.deepEqual(string.get('rgb(100% 30% 90%)'), {model: 'rgb', value: [255, 77, 229, 1]});
 assert.deepEqual(string.get('transparent'), {model: 'rgb', value: [0, 0, 0, 0]});
+assert.deepEqual(string.get('blue'), {model: 'rgb', value: [0, 0, 255, 1]});
+assert.deepEqual(string.get('BLUE'), {model: 'rgb', value: [0, 0, 255, 1]});
 assert.deepEqual(string.get('hsl(240, 100%, 50.5%)'), {model: 'hsl', value: [240, 100, 50.5, 1]});
 assert.deepEqual(string.get('hsl(-480, 100%, 50.5%)'), {model: 'hsl', value: [240, 100, 50.5, 1]});
 assert.deepEqual(string.get('hsl(240 100% 50.5%)'), {model: 'hsl', value: [240, 100, 50.5, 1]});


### PR DESCRIPTION
### Description

Normalize string before checking it to be able to handle uppercase letters.

Closes #80.

### Changes

- Add normalize function
- Run normalize function on any string passed in before checking it
- Add tests for uppercase letters


### Testing

- Be on master
- Call the library with named color with uppercase letters: `cs.get("BLUE")`
- Note that a null value is returned
- Switch to this branch
- Call the library with named color with uppercase letters: `cs.get("BLUE")`
- Note that an array of numbers is returned representing the named color

### Notes

- The normalize function only handles transforming to lowercase right now, but could be extended in the future