### PR TITLE
fix: get.rgb() returning invalid results with named color

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,8 @@ cs.get.rgb = function (string) {
 			return null;
 		}
 
-		rgb = [...colorNames[match[1]]];
+		// eslint-disable-next-line unicorn/prefer-spread
+		rgb = colorNames[match[1]].slice();
 		rgb[3] = 1;
 
 		return rgb;

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ cs.get.rgb = function (string) {
 			return null;
 		}
 
-		rgb = colorNames[match[1]];
+		rgb = [...colorNames[match[1]]];
 		rgb[3] = 1;
 
 		return rgb;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "color-string",
   "description": "Parser and generator for CSS color strings",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": "Josh Junon (https://github.com/qix-)",
   "contributors": [
     "Maxime Thirouin",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "color-string",
   "description": "Parser and generator for CSS color strings",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "author": "Josh Junon (https://github.com/qix-)",
   "contributors": [
     "Maxime Thirouin",

--- a/test.js
+++ b/test.js
@@ -110,6 +110,15 @@ assert.deepEqual(string.get.hwb('hwb(-10.0deg, 100%, 50.5%, +0.6)'), [350, 100, 
 assert.deepEqual(string.get.rgb('blue'), [0, 0, 255, 1]);
 assert.deepEqual(string.get.rgb('blue'), [0, 0, 255, 1]);
 
+// Changing the returned array shouldn't change the array when called with the same named color
+{
+	const col = string.get.rgb('red');
+	assert.deepEqual(col, [255, 0, 0, 1]);
+	col[0] = 0;
+	assert.deepEqual(col, [0, 0, 0, 1]);
+	assert.deepEqual(string.get.rgb('red'), [255, 0, 0, 1]);
+}
+
 // Alpha
 assert.deepEqual(normalizeAlpha(string.get.rgb('#fffa')), [255, 255, 255, '0.67']);
 assert.deepEqual(string.get.rgb('#c814e933'), [200, 20, 233, 0.2]);


### PR DESCRIPTION
Fixed a bug where the ```get.rgb()``` function returned invalid results if called with named colors and the returned array is modified then called with the same named color.