### PR TITLE
fix: clamp out-of-range channels in to.hex

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,7 +224,7 @@ function clamp(number_, min, max) {
 }
 
 function hexDouble(number_) {
-	const string_ = Math.round(number_).toString(16).toUpperCase();
+	const string_ = clamp(Math.round(number_), 0, 255).toString(16).toUpperCase();
 	return (string_.length < 2) ? '0' + string_ : string_;
 }
 

--- a/test.js
+++ b/test.js
@@ -241,3 +241,11 @@ Object.keys(Object.getOwnPropertyDescriptors(Object.prototype))
 
 // Make sure writing decimal values as hex doesn't cause bizarre output (regression test, #25)
 assert.equal(string.to.hex(44.2, 83.8, 44), '#2C542C');
+
+// Make sure out-of-range channels clamp to a valid hex byte instead of emitting
+// malformed hex that get.rgb() cannot parse back (e.g. a 255.5 that rounds to 256).
+assert.equal(string.to.hex(255.5, 0, 0), '#FF0000');
+assert.equal(string.to.hex(256, 0, 0), '#FF0000');
+assert.equal(string.to.hex(300, 128, -20), '#FF8000');
+assert.equal(string.to.hex(-1, 0, 0), '#000000');
+assert.equal(string.to.hex(0, 0, 0, -0.5), '#00000000');


### PR DESCRIPTION
### Problem

`to.hex()` passes each channel straight to the private `hexDouble()` helper, which rounds but never clamps to `[0, 255]`. A channel that is out of range — or an innocuous fractional value that *rounds* past 255 — serializes to malformed hex that `get.rgb()` cannot parse back, breaking the parse ⇄ format round-trip:

```js
const cs = require('color-string');

cs.to.hex(255.5, 0, 0)    // '#1000000'    (255.5 rounds to 256 → 3-digit byte)
cs.to.hex(256, 0, 0)      // '#1000000'
cs.to.hex(300, 128, -20)  // '#12C80-14'
cs.to.hex(-1, 0, 0)       // '#-10000'     (sign leaks into the string)
cs.to.hex(0, 0, 0, -0.5)  // '#000000-7F'

cs.get.rgb('#1000000')    // null — the parser rejects its own serializer's output
```

`get.rgb` already clamps channels to `[0, 255]` on the way in, so `to.hex` is the asymmetric side. A round-trip fuzz over fractional channels in `[-5, 260]` produces an invalid hex shape (not 6/8 digits) for ~10% of inputs.

### Fix

Clamp inside `hexDouble` using the existing `clamp()` helper. `hexDouble` is only ever used to emit a single hex byte (the three channels and the alpha byte), so clamping to `[0, 255]` there is correct for every caller and keeps the change to one line. Every output is now a valid 6/8-digit hex string.

This is the out-of-range sibling of the decimal-output fix in #25 (`to.hex(44.2, 83.8, 44)`), which added `Math.round` but not clamping.

### Tests

Added assertions next to the existing #25 regression test covering fractional, over-range, negative, and negative-alpha channels. They fail before the change (e.g. `'#1000000' == '#FF0000'`) and pass after. Full suite (`xo && tsd && node test.js`) is green.