### PR TITLE
Fix percent rounding: 2.55 is not exactly representable (rgb(50%, 50%, 50%) → 127, expected 128)

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ cs.get.rgb = function (string) {
 		}
 	} else if (match = string.match(per)) {
 		for (i = 0; i < 3; i++) {
-			rgb[i] = Math.round(Number.parseFloat(match[i + 1]) * 2.55);
+			rgb[i] = Math.round(Number.parseFloat(match[i + 1]) * 255 / 100);
 		}
 
 		if (match[4]) {

--- a/test.js
+++ b/test.js
@@ -19,8 +19,12 @@ assert.deepEqual(string.get.rgb('rgb(244.5, 233.5, 100.5)'), [244.5, 233.5, 100.
 assert.deepEqual(string.get.rgb('rgb(244.5 233.5 100.5)'), [244.5, 233.5, 100.5, 1]);
 assert.deepEqual(string.get.rgb('rgb(2.44E2, 2.33e2, 1.00E2)'), [244, 233, 100, 1]);
 assert.deepEqual(string.get.rgb('rgb(2.44E2 2.33e2 1.00E2)'), [244, 233, 100, 1]);
-assert.deepEqual(string.get.rgb('rgb(100%, 30%, 90%)'), [255, 77, 229, 1]);
-assert.deepEqual(string.get.rgb('RGB(100% 30% 90%)'), [255, 77, 229, 1]);
+assert.deepEqual(string.get.rgb('rgb(100%, 30%, 90%)'), [255, 77, 230, 1]);
+assert.deepEqual(string.get.rgb('RGB(100% 30% 90%)'), [255, 77, 230, 1]);
+// Percentage rounding: 2.55 is not exactly representable in floating point, so p * 2.55 lands just
+// below the half-integer for p = 50 and p = 90 (50% -> 127, 90% -> 229). p * 255 / 100 is exact.
+assert.deepEqual(string.get.rgb('rgb(50%, 50%, 50%)'), [128, 128, 128, 1]);
+assert.deepEqual(string.get.rgb('rgb(90%, 90%, 90%)'), [230, 230, 230, 1]);
 assert.deepEqual(string.get.rgb('transparent'), [0, 0, 0, 0]);
 assert.deepEqual(string.get.rgb('blue'), [0, 0, 255, 1]);
 assert.deepEqual(string.get.rgb('BLUE'), [0, 0, 255, 1]);
@@ -45,8 +49,8 @@ assert.deepEqual(string.get('rgb(244.5, 233.5, 100.5)'), {model: 'rgb', value: [
 assert.deepEqual(string.get('rgb(244.5 233.5 100.5)'), {model: 'rgb', value: [244.5, 233.5, 100.5, 1]});
 assert.deepEqual(string.get('rgb(2.44E2, 2.33e2, 1.00E2)'), {model: 'rgb', value: [244, 233, 100, 1]});
 assert.deepEqual(string.get('rgb(2.44E2 2.33e2 1.00E2)'), {model: 'rgb', value: [244, 233, 100, 1]});
-assert.deepEqual(string.get('rgb(100%, 30%, 90%)'), {model: 'rgb', value: [255, 77, 229, 1]});
-assert.deepEqual(string.get('rgb(100% 30% 90%)'), {model: 'rgb', value: [255, 77, 229, 1]});
+assert.deepEqual(string.get('rgb(100%, 30%, 90%)'), {model: 'rgb', value: [255, 77, 230, 1]});
+assert.deepEqual(string.get('rgb(100% 30% 90%)'), {model: 'rgb', value: [255, 77, 230, 1]});
 assert.deepEqual(string.get('transparent'), {model: 'rgb', value: [0, 0, 0, 0]});
 assert.deepEqual(string.get('blue'), {model: 'rgb', value: [0, 0, 255, 1]});
 assert.deepEqual(string.get('BLUE'), {model: 'rgb', value: [0, 0, 255, 1]});
@@ -150,11 +154,11 @@ assert.deepEqual(string.get.rgb('rgba(200 20 233 / 0)'), [200, 20, 233, 0]);
 assert.deepEqual(string.get.rgb('rgba(200 20 233 0)'), [200, 20, 233, 0]);
 assert.deepEqual(string.get.rgb('rgba(200 20 233 / 0%)'), [200, 20, 233, 0]);
 assert.deepEqual(string.get.rgb('rgba(200 20 233 0%)'), [200, 20, 233, 0]);
-assert.deepEqual(string.get.rgb('rgba(100%, 30%, 90%, 0.2)'), [255, 77, 229, 0.2]);
-assert.deepEqual(string.get.rgb('rgba(100% 30% 90% / 0.2)'), [255, 77, 229, 0.2]);
-assert.deepEqual(string.get.rgb('rgba(100% 30% 90% 0.2)'), [255, 77, 229, 0.2]);
-assert.deepEqual(string.get.rgb('rgba(100% 30% 90% / 20%)'), [255, 77, 229, 0.2]);
-assert.deepEqual(string.get.rgb('rgba(100% 30% 90% 20%)'), [255, 77, 229, 0.2]);
+assert.deepEqual(string.get.rgb('rgba(100%, 30%, 90%, 0.2)'), [255, 77, 230, 0.2]);
+assert.deepEqual(string.get.rgb('rgba(100% 30% 90% / 0.2)'), [255, 77, 230, 0.2]);
+assert.deepEqual(string.get.rgb('rgba(100% 30% 90% 0.2)'), [255, 77, 230, 0.2]);
+assert.deepEqual(string.get.rgb('rgba(100% 30% 90% / 20%)'), [255, 77, 230, 0.2]);
+assert.deepEqual(string.get.rgb('rgba(100% 30% 90% 20%)'), [255, 77, 230, 0.2]);
 assert.deepEqual(string.get.hsl('hsla(200, 20%, 33%, 0.2)'), [200, 20, 33, 0.2]);
 assert.deepEqual(string.get.hsl('hsla(200, 20%, 33%, 1e-7)'), [200, 20, 33, 1e-7]);
 assert.deepEqual(string.get.hsl('hsl(200 20% 33% / 0.2)'), [200, 20, 33, 0.2]);


### PR DESCRIPTION
`rgb()` percentage channels convert via `Math.round(p * 2.55)`. Since `2.55` has no exact float64 representation (it's `2.5499999999999998…`), the product lands just *below* the half-integer for `p = 50` and `p = 90`:

```js
color('rgb(50%, 50%, 50%)').rgb()  // [127, 127, 127] — expected [128, 128, 128]
color('rgb(90%, 90%, 90%)').rgb()  // [229, …] — expected [230, …]
```

**The fix:** `Math.round(p * 255 / 100)`, which computes the conversion exactly and is self-documenting. **If you'd rather keep the single multiply**, `Math.round(p * 2.5500000000000003)` (the next representable double above 2.55) also works — both candidates were verified against exact rational arithmetic over ~11k percent inputs (all integers, tenths, hundredths, plus adversarial near-half-integer decimals), zero divergences for either. Happy to switch to whichever you prefer.

**Blast radius, measured exhaustively:** across integer percents 0–100, exactly two values change — `50% : 127 → 128` and `90% : 229 → 230`. Everything else is byte-identical.

**Tests:** the existing suite pinned the old values in nine assertions (`[255, 77, 229, …]` for the `30%/90%` cases) — updated here — and two regression cases are added with a short comment on the float mechanics.

Found via characterization testing while building verification tooling against color-string. It's a (tiny) behavioral change, so version it however you see fit — happy to adjust anything.